### PR TITLE
feature: Use GitHub Actions for NuGet Releases

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,88 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [ main ]
+
+env:
+  configuration: Release
+  productNamespacePrefix: "Live.Avalonia"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    outputs:
+      nbgv: ${{ steps.nbgv.outputs.SemVer2 }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: 'recursive'
+
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.100-rc.2.20479.15
+
+    - name: NBGV
+      id: nbgv
+      uses: dotnet/nbgv@master
+      with:
+        setAllVars: true
+
+    - name: NuGet Restore
+      run: dotnet restore
+      working-directory: src
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Build
+      run: dotnet build --configuration ${{ env.configuration }}
+      working-directory: src
+
+    - name: Create NuGet Artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: nuget
+        path: '**/*.nupkg'
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: contains(github.event.pull_request.labels.*.name, 'release') && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Download NuGet Packages
+      uses: actions/download-artifact@v2
+      with:
+        name: nuget
+
+    - name: Changelog
+      uses: glennawatson/ChangeLog@v1
+      id: changelog
+
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+          tag_name: ${{ needs.build.outputs.nbgv }}
+          release_name: ${{ needs.build.outputs.nbgv }}
+          body: |
+            ${{ steps.changelog.outputs.commitLog }}
+
+    - name: NuGet Push
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
+        SOURCE_URL: https://api.nuget.org/v3/index.json
+      run: |
+        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} **/*.nupkg

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,14 +36,12 @@ jobs:
 
     - name: NuGet Restore
       run: dotnet restore
-      working-directory: src
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1
 
     - name: Build
       run: dotnet build --configuration ${{ env.configuration }}
-      working-directory: src
 
     - name: Create NuGet Artifacts
       uses: actions/upload-artifact@master

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -16,6 +16,6 @@
         <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="$(MSBuildThisFileDirectory)..\LICENSE" Pack="true" PackagePath="LICENSE" />
+        <None Include="$(MSBuildThisFileDirectory)\LICENSE" Pack="true" PackagePath="LICENSE" />
     </ItemGroup>
 </Project>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,0 +1,21 @@
+<Project>
+    <PropertyGroup>
+        <Product>Live.Avalonia</Product>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/avaloniacommunity/live.avalonia</PackageProjectUrl>
+        <Description>Avalonia live reloading window.</Description>
+        <PackageReleaseNotes>https://github.com/avaloniacommunity/live.avalonia/releases</PackageReleaseNotes>
+        <RepositoryUrl>https://github.com/avaloniacommunity/live.avalonia.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <PackageTags>dotnet, reloading, avalonia, avaloniaui, xaml</PackageTags>
+        <Copyright>Copyright (c) 2020 Avalonia Community</Copyright>
+        <Authors>Avalonia Community</Authors>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)..\LICENSE" Pack="true" PackagePath="LICENSE" />
+    </ItemGroup>
+</Project>

--- a/Live.Avalonia.FuncUI.Sample/Live.Avalonia.FuncUI.Sample.fsproj
+++ b/Live.Avalonia.FuncUI.Sample/Live.Avalonia.FuncUI.Sample.fsproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
+        <IsPackable>false</IsPackable>
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 

--- a/Live.Avalonia.Sample.Library/Live.Avalonia.Sample.Library.csproj
+++ b/Live.Avalonia.Sample.Library/Live.Avalonia.Sample.Library.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="ReactiveUI.Validation" Version="1.4.15" />

--- a/Live.Avalonia.Sample/Live.Avalonia.Sample.csproj
+++ b/Live.Avalonia.Sample/Live.Avalonia.Sample.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
+        <IsPackable>false</IsPackable>
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>

--- a/Live.Avalonia/Live.Avalonia.csproj
+++ b/Live.Avalonia/Live.Avalonia.csproj
@@ -2,17 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>true</IsPackable>
-    <AssemblyName>Live.Avalonia</AssemblyName>
-    <Description>Avalonia live reloading window.</Description>
-    <PackageTags>dotnet, reloading, avalonia, avaloniaui, xaml</PackageTags>
-    <RepositoryUrl>https://github.com/worldbeater/avalonia.hotreload.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>https://github.com/worldbeater/avalonia.hotreload</PackageProjectUrl>
-    <PackageOutputPath>./nupkg</PackageOutputPath>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright (c) 2020 Artyom Gorchakov</Copyright>
-    <Authors>Artyom Gorchakov and Contributors</Authors>
-    <Version>1.0.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.9.11" />

--- a/Live.Avalonia/Live.Avalonia.csproj
+++ b/Live.Avalonia/Live.Avalonia.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.1",
+    "publicReleaseRefSpec": [
+      "^refs/heads/main$", // we release out of main
+      "^refs/heads/rel/\\d+\\.\\d+\\.\\d+" // we also release branches starting with rel/N.N.N
+    ],
+    "nugetPackageVersion":{
+      "semVer": 2
+    },
+    "cloudBuild": {
+      "setVersionVariables": true,
+      "buildNumber": {
+        "enabled": false
+      }
+    }
+  }


### PR DESCRIPTION
This PR enables GitHub Actions for this repository. From now on, after a pull request marked with the `release` label is merged, a new `NuGet` package will be shipped and a new release with a change log will be published to GitHub Releases. Ideally, we should use the [Commit Prefixes](https://github.com/glennawatson/ChangeLog#commit-prefixes) and squash-and-merge strategy to enable automatic commit categorization in release notes.

The `yml` configuration is based on the configurations we use in [ReactiveUI.Validation](https://github.com/reactiveui/reactiveui.validation). 