### PR TITLE
Speed up reload using file system watcher instead of checking every second

### DIFF
--- a/Live.Avalonia.FuncUI.Sample/Live.Avalonia.FuncUI.Sample.fsproj
+++ b/Live.Avalonia.FuncUI.Sample/Live.Avalonia.FuncUI.Sample.fsproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="FSharp.SystemTextJson" Version="0.17.4" />
         <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="$(FuncUIVersion)" />
         <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="$(FuncUIVersion)" />
         <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="$(FuncUIVersion)" />

--- a/Live.Avalonia.FuncUI.Sample/Program.fs
+++ b/Live.Avalonia.FuncUI.Sample/Program.fs
@@ -1,6 +1,8 @@
-﻿namespace Live.Avalonia.FuncUI.Sample
+﻿module Live.Avalonia.FuncUI.Sample.Program
 
 open System
+open System.Text.Json
+open System.Text.Json.Serialization
 open Elmish
 open Avalonia
 open Avalonia.Controls
@@ -10,12 +12,35 @@ open Avalonia.FuncUI
 open Avalonia.FuncUI.Elmish
 open Avalonia.FuncUI.Components.Hosts
 
-
-type MainControl() as this =
+let transferState<'t> oldState =
+    let jsonOptions = JsonSerializerOptions()
+    jsonOptions.Converters.Add(JsonFSharpConverter())
+    
+    try
+        let json = JsonSerializer.Serialize(oldState, jsonOptions)
+        let state = JsonSerializer.Deserialize<'t>(json, jsonOptions)        
+        match box state with
+        | null -> None
+        | _ -> Some state
+    with ex ->
+        Console.Write $"Error restoring state: {ex}"
+        None
+    
+type MainControl(window: Window) as this =
     inherit HostControl()
     do
-        Elmish.Program.mkSimple (fun () -> Counter.init) Counter.update Counter.view
+        // Instead of just creating default init state, try to recover state from window.DataContext
+        let hotInit () = 
+            match transferState<Counter.State> window.DataContext with
+            | Some newState ->
+                Console.WriteLine $"Restored state %O{newState}"
+                newState
+            | None -> Counter.init
+        
+        Elmish.Program.mkSimple hotInit Counter.update Counter.view
         |> Program.withHost this
+        // Every time state changes, save state to window.DataContext
+        |> Program.withTrace (fun _ state -> window.DataContext <- state)
         |> Program.run
 
         
@@ -23,7 +48,8 @@ type App() =
     inherit Application()
     
     interface ILiveView with
-        member __.CreateView(window: Window) = MainControl() :> obj
+        member _.CreateView(window: Window) =
+            MainControl(window) :> obj
 
     override this.Initialize() =
         this.Styles.Load "avares://Avalonia.Themes.Default/DefaultTheme.xaml"
@@ -32,18 +58,16 @@ type App() =
     override this.OnFrameworkInitializationCompleted() =
         match this.ApplicationLifetime with
         | :? IClassicDesktopStyleApplicationLifetime as desktopLifetime ->
-            let window = new LiveViewHost(this, fun msg -> printfn "%s" msg);
-            window.StartWatchingSourceFilesForHotReloading();
-            window.Show();
+            let window = new LiveViewHost(this, fun msg -> printfn $"%s{msg}")
+            window.StartWatchingSourceFilesForHotReloading()
+            window.Show()
             base.OnFrameworkInitializationCompleted()
         | _ -> ()
 
-module Program =
-
-    [<EntryPoint>]
-    let main(args: string[]) =
-        AppBuilder
-            .Configure<App>()
-            .UsePlatformDetect()
-            .UseSkia()
-            .StartWithClassicDesktopLifetime(args)
+[<EntryPoint>]
+let main (args: string array) =
+    AppBuilder
+        .Configure<App>()
+        .UsePlatformDetect()
+        .UseSkia()
+        .StartWithClassicDesktopLifetime(args)

--- a/Live.Avalonia/LiveFileWatcher.cs
+++ b/Live.Avalonia/LiveFileWatcher.cs
@@ -11,7 +11,7 @@ namespace Live.Avalonia
         readonly Subject<string> _fileChanged = new Subject<string>();
         readonly Action<string> _logger;
 
-        FileSystemWatcher watcher = new FileSystemWatcher()
+        readonly FileSystemWatcher watcher = new FileSystemWatcher()
         {
             EnableRaisingEvents = false
         };

--- a/Live.Avalonia/LiveSourceWatcher.cs
+++ b/Live.Avalonia/LiveSourceWatcher.cs
@@ -11,7 +11,7 @@ namespace Live.Avalonia
 
         public LiveSourceWatcher(Action<string> logger) => _logger = logger;
 
-        public string StartRebuildingAssemblySources(string assemblyPath)
+        public (string dir, string file) StartRebuildingAssemblySources(string assemblyPath)
         {
             _logger("Attempting to run 'dotnet watch' command for assembly sources...");
             var binDirectoryPath = FindAscendantDirectory(assemblyPath, "bin");
@@ -22,7 +22,10 @@ namespace Live.Avalonia
             _logger($"Preparing .live-bin directory...");
             var dotnetWatchBuildPath = Path.Combine(binDirectoryPath, ".live-bin") + Path.DirectorySeparatorChar;
             if (Directory.Exists(dotnetWatchBuildPath))
+            {
                 Directory.Delete(dotnetWatchBuildPath, true);
+                Directory.CreateDirectory(dotnetWatchBuildPath);
+            }
 
             _logger($"Executing 'dotnet watch' command from {projectDirectory}, building into {dotnetWatchBuildPath}");
             _dotnetWatchBuildProcess = new Process
@@ -42,7 +45,8 @@ namespace Live.Avalonia
             _dotnetWatchBuildProcess.Start();
             _logger($"Successfully managed to start 'dotnet watch' process with id {_dotnetWatchBuildProcess.Id}");
             var separator = Path.DirectorySeparatorChar;
-            return assemblyPath.Replace($"{separator}bin{separator}", $"{separator}bin{separator}.live-bin{separator}");
+            var liveAssemblyPath = assemblyPath.Replace($"{separator}bin{separator}", $"{separator}bin{separator}.live-bin{separator}");
+            return (dir: dotnetWatchBuildPath, file: liveAssemblyPath);
         }
         
         public void Dispose()

--- a/Live.Avalonia/LiveViewHost.cs
+++ b/Live.Avalonia/LiveViewHost.cs
@@ -35,8 +35,8 @@ namespace Live.Avalonia
         public void StartWatchingSourceFilesForHotReloading()
         {
             _logger("Starting source and assembly file watchers...");
-            var liveAssemblyPath = _sourceWatcher.StartRebuildingAssemblySources(_assemblyPath);
-            _assemblyWatcher.StartWatchingFileCreation(liveAssemblyPath);
+            var (liveAssemblyDir, liveAssemblyFile) = _sourceWatcher.StartRebuildingAssemblySources(_assemblyPath);
+            _assemblyWatcher.StartWatchingFileCreation(liveAssemblyDir, liveAssemblyFile);
         }
 
         public void Dispose()


### PR DESCRIPTION
This approach utilizes a file system watcher instead of computing a hash every second to see if the file changed. 

Should be on average 0.5s faster. 